### PR TITLE
[FEAT] 별자리 크기 조정과 오늘 날짜 강조 컴포넌트 구현 완료

### DIFF
--- a/src/pages/diary/components/Constellation.tsx
+++ b/src/pages/diary/components/Constellation.tsx
@@ -8,7 +8,7 @@ import { EMOTION_IMG } from "../constants/emotion_img";
 import { LINES } from "../constants/line";
 import { MONTH_CONSTELLATION } from "../constants/month";
 import { useMood } from "../hooks/useMood";
-import { Day, Line, Star, StarImg, ToggleButton, Wrapper } from "../styles/Constellation";
+import { Day, Light, Line, Star, StarImg, ToggleButton, Wrapper } from "../styles/Constellation";
 import { createLineProps } from "../utils/createLineProps";
 
 const Constellation = ({ date }: { date: Date }) => {
@@ -49,6 +49,9 @@ const Constellation = ({ date }: { date: Date }) => {
               <Day $toggle={toggle} $x={constellation.text?.x ?? 0} $y={constellation.text?.y ?? 0}>
                 {day}
               </Day>
+              {date.getFullYear() == new Date().getFullYear() &&
+                date.getMonth() == new Date().getMonth() &&
+                Number(day) == new Date().getDate() && <Light $big={constellation.big} />}
             </Star>
           );
         })}

--- a/src/pages/diary/index.tsx
+++ b/src/pages/diary/index.tsx
@@ -11,7 +11,9 @@ export default function Diary() {
         <Title>일기</Title>
       </Header>
       <DateNavigation handleMoveMonth={handleMoveMonth} date={new Date(date)} />
-      <Constellation date={new Date(date)} />
+      <div style={{ display: "flex", justifyContent: "center" }}>
+        <Constellation date={new Date(date)} />
+      </div>
       <Message>{"개구리가 우물 안에서 볼 밤하늘을 밝혀주세요"}</Message>
     </Page>
   );

--- a/src/pages/diary/styles/Constellation.tsx
+++ b/src/pages/diary/styles/Constellation.tsx
@@ -2,14 +2,18 @@ import styled from "styled-components";
 
 export const Wrapper = styled.div`
   position: relative;
-  margin-top: clamp(0px, calc((100vh - 700px) * 35 / 112), 35px);
-  width: auto;
-  height: clamp(360px, 60vh, 451px);
+  margin-top: clamp(20px, calc((100vh - 700px) * 35 / 112), 35px);
+  width: clamp(220px, min(85vw, calc(55vh * 352 / 451)), 352px);
+  height: clamp(282px, min(calc(85vw * 451 / 352), 55vh), 451px);
   aspect-ratio: 352 / 451;
-  max-width: min(352px, 90vw);
-  max-height: 100%;
-  --constellation-scale-w: clamp(0.6, calc(min(90vw, 352px) / 352px), 1);
-  --constellation-scale-h: clamp(0.6, calc(clamp(360px, 60vh, 451px) / 451px), 1);
+  max-width: 352px;
+  max-height: 451px;
+  --constellation-scale-w: clamp(0.625, calc(min(85vw, 352px) / 352px), 1);
+  --constellation-scale-h: clamp(
+    0.625,
+    calc(clamp(282px, min(calc(85vw * 451 / 352), 55vh), 451px) / 451px),
+    1
+  );
   --constellation-scale: min(var(--constellation-scale-w), var(--constellation-scale-h));
 `;
 
@@ -28,12 +32,15 @@ export const Star = styled.div<{ $x: number; $y: number }>`
   position: absolute;
   left: calc(${props => props.$x}px * var(--constellation-scale));
   top: calc(${props => props.$y}px * var(--constellation-scale));
-  z-index: 1;
+  cursor: pointer;
 `;
 
 export const StarImg = styled.img<{ $big: boolean }>`
+  display: block;
   width: ${props => (props.$big ? "clamp(28px, 8.5vw, 34.7px)" : "clamp(12px, 4.5vw, 17px)")};
   height: ${props => (props.$big ? "clamp(28px, 8.5vw, 34.7px)" : "clamp(12px, 4.5vw, 17px)")};
+  z-index: 1;
+  position: relative;
 `;
 
 export const Day = styled.span<{ $toggle: boolean; $x: number; $y: number }>`
@@ -44,6 +51,19 @@ export const Day = styled.span<{ $toggle: boolean; $x: number; $y: number }>`
   top: calc(${props => props.$y}px * var(--constellation-scale));
   left: calc(${props => props.$x}px * var(--constellation-scale));
   white-space: nowrap;
+`;
+
+export const Light = styled.div<{ $big: boolean }>`
+  background: #fff;
+  border: 1px solid #000;
+  filter: ${props => (props.$big ? "blur(8.55px)" : "blur(5px)")};
+  width: ${props => (props.$big ? "clamp(28px, 8.5vw, 34.7px)" : "clamp(21px, 4.5vw, 25px)")};
+  height: ${props => (props.$big ? "clamp(28px, 8.5vw, 34.7px)" : "clamp(21px, 4.5vw, 25px)")};
+  border-radius: 50%;
+  position: absolute;
+  left: ${props => (props.$big ? 0 : -1.5)}px;
+  top: ${props => (props.$big ? 0 : -1.5)}px;
+  z-index: 0;
 `;
 
 export const ToggleButton = styled.button<{ $toggle: boolean }>`

--- a/src/pages/diary/styles/index.tsx
+++ b/src/pages/diary/styles/index.tsx
@@ -31,6 +31,6 @@ export const Title = styled.h1`
 export const Message = styled.h3`
   font-size: clamp(var(--fs-sm), 2vw, var(--fs-md));
   font-weight: 500;
-  margin-top: clamp(12px, calc((100vh - 700px) * 26 / 112), 38px);
+  margin-top: clamp(24px, calc((100vh - 700px) * 26 / 112), 38px);
   color: white;
 `;


### PR DESCRIPTION
## 관련 Issue

#82 

close #82 

## PR 설명

IPhone SE 기준 별자리 크기를 IPhone XR 기준 별자리 크기의 비율을 유지하면서 조정이 되도록 스타일을 수정했습니다.
오늘 날짜를 강조하는 별빛 컴포넌트도 구현 완료했습니다.

## 리뷰어 참고
